### PR TITLE
Add ability to create multiple variable templates

### DIFF
--- a/resources/lib/script.py
+++ b/resources/lib/script.py
@@ -53,4 +53,4 @@ class Script(object):
             return ViewTypes().update_xml(skinfolder=self.params.get('folder'), **self.params)
         else:
             from resources.lib.skinvariables import SkinVariables
-            return SkinVariables(self.params).update_xml(skinfolder=self.params.get('folder'), **self.params)
+            return SkinVariables(template=self.params.get('template'), skinfolder=self.params.get('folder')).update_xml(**self.params)

--- a/resources/lib/script.py
+++ b/resources/lib/script.py
@@ -53,4 +53,4 @@ class Script(object):
             return ViewTypes().update_xml(skinfolder=self.params.get('folder'), **self.params)
         else:
             from resources.lib.skinvariables import SkinVariables
-            return SkinVariables().update_xml(skinfolder=self.params.get('folder'), **self.params)
+            return SkinVariables(self.params).update_xml(skinfolder=self.params.get('folder'), **self.params)

--- a/resources/lib/skinvariables.py
+++ b/resources/lib/skinvariables.py
@@ -15,9 +15,11 @@ ADDON = xbmcaddon.Addon()
 
 
 class SkinVariables(object):
-    def __init__(self):
-        self.content = self.build_json('special://skin/shortcuts/skinvariables.xml')
-        self.content = self.content or load_filecontent('special://skin/shortcuts/skinvariables.json')
+    def __init__(self, params):
+        self.params = params
+        self.template = f"skinvariables-{self.params.get('template')}" if self.params.get('template') else 'skinvariables'
+        self.content = self.build_json(f'special://skin/shortcuts/{self.template}.xml')
+        self.content = self.content or load_filecontent(f'special://skin/shortcuts/{self.template}.json')
         self.meta = loads(self.content) or []
 
     def build_json(self, file):
@@ -165,7 +167,7 @@ class SkinVariables(object):
         folders = [skinfolder] if skinfolder else get_skinfolders()
         if folders:
             write_skinfile(
-                folders=folders, filename='script-skinvariables-includes.xml',
+                folders=folders, filename=f'script-{self.template}-includes.xml',
                 content=make_xml_includes(xmltree, p_dialog=p_dialog),
                 hashvalue=hashvalue, hashname='script-skinvariables-hash')
 

--- a/resources/lib/skinvariables.py
+++ b/resources/lib/skinvariables.py
@@ -15,9 +15,11 @@ ADDON = xbmcaddon.Addon()
 
 
 class SkinVariables(object):
-    def __init__(self, params):
-        self.params = params
-        self.template = f"skinvariables-{self.params.get('template')}" if self.params.get('template') else 'skinvariables'
+    def __init__(self, template: str = None, skinfolder: str = None):
+        self.template = f"skinvariables-{template}" if template else 'skinvariables'
+        self.filename = f'script-{self.template}-includes.xml'
+        self.hashname = f'script-{self.template}-hash'
+        self.folders = [skinfolder] if skinfolder else get_skinfolders()
         self.content = self.build_json(f'special://skin/shortcuts/{self.template}.xml')
         self.content = self.content or load_filecontent(f'special://skin/shortcuts/{self.template}.json')
         self.meta = loads(self.content) or []
@@ -140,14 +142,14 @@ class SkinVariables(object):
             skin_vars.append(build_var)
         return skin_vars
 
-    def update_xml(self, force=False, skinfolder=None, no_reload=False, **kwargs):
+    def update_xml(self, force=False, no_reload=False, **kwargs):
         if not self.meta:
             return
 
         hashvalue = make_hash(self.content)
 
         if not force:  # Allow overriding over built check
-            last_version = xbmc.getInfoLabel('Skin.String(script-skinvariables-hash)')
+            last_version = xbmc.getInfoLabel(f'Skin.String({self.hashname})')
             if hashvalue and last_version and hashvalue == last_version:
                 return  # Already updated
 
@@ -163,13 +165,12 @@ class SkinVariables(object):
                 item = self.get_skinvariable(i, expression=True)
             xmltree = xmltree + item if item else xmltree
 
-        # Get folder to save to
-        folders = [skinfolder] if skinfolder else get_skinfolders()
-        if folders:
+        # Save to folder
+        if self.folders:
             write_skinfile(
-                folders=folders, filename=f'script-{self.template}-includes.xml',
+                folders=self.folders, filename=self.filename,
                 content=make_xml_includes(xmltree, p_dialog=p_dialog),
-                hashvalue=hashvalue, hashname='script-skinvariables-hash')
+                hashvalue=hashvalue, hashname=self.hashname)
 
         p_dialog.close()
         xbmc.executebuiltin('ReloadSkin()') if not no_reload else None


### PR DESCRIPTION
Allow for building multiple skinvariable templates:-

`RunScript(script.skinvariables,action=buildvariables)`
Will build the default script-skinvariables-includes.xml from the template skinvariables.xml/json

`RunScript(script.skinvariables,action=buildvariables,template=backgrounds)`
Will build script-skinvariables-backgrounds-includes.xml from the template skinvariables-backgrounds.xml/json

Skinvariable include files can get very large and hard to navigate, this pull request allows the includes to be built in smaller more modular chunks.

Also I found myself needing to manually edit small portions of the generated includes, meaning that if another part of the template needed to be changed I would lose all of my manual edits, this way I can split the template, allowing manual changes to be made where necessary and still rebuild other parts without losing my manual changes.

