### PR TITLE
Fix UnboundLocalError when Files.GetSources returns an error

### DIFF
--- a/resources/lib/shortcuts/jsonrpc.py
+++ b/resources/lib/shortcuts/jsonrpc.py
@@ -22,6 +22,7 @@ class GetDirectoryJSONRPC(GetDirectoryCommon):
         from contextlib import suppress
         from jurialmunkey.jsnrpc import get_jsonrpc
         response = get_jsonrpc("Files.GetSources", {"media": DIRECTORY_SOURCES[self.path]})
+        result = None
         with suppress(KeyError):
             result = response['result']['sources']
         return result or [{}]


### PR DESCRIPTION
`GetDirectoryJSONRPC.get_directory_source()` assigns `result` only inside the
`suppress(KeyError)` block:

```python
response = get_jsonrpc("Files.GetSources", {"media": DIRECTORY_SOURCES[self.path]})
with suppress(KeyError):
    result = response['result']['sources']
return result or [{}]
```

A JSON-RPC **error** response has no `result` key, so the `KeyError` is suppressed,
`result` is never bound, and the `return` raises `UnboundLocalError`. That escapes
`get_directory_source()` and kills the script instead of falling back to `[{}]`.

The live example is `sources://games/`, which maps to media `"game"`. Kodi's
`Files.Media` enum is `video | music | pictures | files | programs`, so the call is
rejected by schema validation and the browser dies as soon as you open that group in
the shortcut editor:

```
Error Type: <class 'UnboundLocalError'>
Error Contents: cannot access local variable 'result' where it is not associated with a value
  File "resources/lib/shortcuts/browser.py", line 129, in get_directory
    if not directory.items and not add_item:
  File "resources/lib/shortcuts/common.py", line 29, in items
    self._items = self.get_items()
  File "resources/lib/shortcuts/jsonrpc.py", line 59, in get_items
    if not self.directory:
  File "resources/lib/shortcuts/jsonrpc.py", line 27, in get_directory_source
    return result or [{}]
UnboundLocalError: cannot access local variable 'result' where it is not associated with a value
```

Seen on Kodi 22.0-BETA1 with Arctic Fuse 3 v3.2.15 and script.skinvariables v2.2.2.

Initialising `result = None` restores the intended fallback: the group opens empty
rather than taking the script down. This isn't specific to games — any error from
`Files.GetSources`, for any media type, currently produces the same crash.
