### PR TITLE
Ask Kodi for game sources by the name it accepts

### DIFF
--- a/resources/lib/shortcuts/jsonrpc.py
+++ b/resources/lib/shortcuts/jsonrpc.py
@@ -9,7 +9,7 @@ DIRECTORY_SOURCES = {
     "sources://pictures/": "pictures",
     "sources://programs/": "programs",
     "sources://files/": "files",
-    "sources://games/": "game",
+    "sources://games/": "games",
 }
 
 


### PR DESCRIPTION
`Files.GetSources` accepts `games`, not `game`. The singular is rejected by schema validation, so browsing **Game Sources** in the shortcut editor returns nothing and a games menu item cannot be created.

Kodi only gained a games entry in the `Files.Media` enum recently, in xbmc/xbmc#29066, and that added `games` alone — matching the key the sources are stored under in `sources.xml` and the `sources://games/` path itself. The singular has never been accepted.

Tested against a Kodi build carrying that change: with `game` the call is refused, with `games` the browser lists the configured game sources and a shortcut created from one resolves to a real path.

Related: #89 stops the refusal taking the whole script down, but the group still comes up empty without this.
